### PR TITLE
🩹 Add missing cspell extension to recommends

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "astro-build.astro-vscode",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "editorconfig.editorconfig"
+    "editorconfig.editorconfig",
+    "streetsidesoftware.code-spell-checker"
   ]
 }


### PR DESCRIPTION
So this won't be an unknown setting anymore
> \# .vscode/settings.json
> {
> ..
> "cSpell.words": ["Astro"]
> ..
> }
